### PR TITLE
Synchronously convert the stream controller into channels

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -286,7 +286,7 @@ class Connection implements AsyncCableConnection {
     final inProgress = _pending[identifier];
     if (inProgress != null) return inProgress.future;
 
-    final completer = Completer<StreamController>();
+    final completer = Completer<StreamController>.sync();
     _pending[identifier] = completer;
     _websocket.add(json.encode({
       "command": "subscribe",

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -286,12 +286,12 @@ class Connection implements AsyncCableConnection {
     final inProgress = _pending[identifier];
     if (inProgress != null) return inProgress.future;
 
+    final completer = Completer<StreamController>();
+    _pending[identifier] = completer;
     _websocket.add(json.encode({
       "command": "subscribe",
       "identifier": identifier,
     }));
-    final completer = Completer<StreamController>();
-    _pending[identifier] = completer;
     return completer.future;
   }
 


### PR DESCRIPTION
To avoid the possibility of missing a channel message received on the websocket straight after the confirm_subscription.