### PR TITLE
Defer cancelling the stream subscription to workaround race in SecureSocket

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -22,8 +22,7 @@ class Channel implements AsyncCableChannel {
   final AsyncCableConnection _connection;
   final Function(String, Map<String, dynamic>) _perform;
 
-  Channel(
-      this._connection,
+  Channel(this._connection,
       {required this.name,
       required this.params,
       required this.subscription,


### PR DESCRIPTION
We've found that if you cancel the subscription while there are still messages left to be read, a race condition results in the following error:
    
      SocketException: Reading from a closed socket
      #0      _RawSecureSocket.read (dart:io/secure_socket.dart:770:7)
      #1      _Socket._onData (dart:io-patch/socket_patch.dart:2323:28)
      #2      _RootZone.runUnaryGuarded (dart:async/zone.dart:1586:10)
      #3      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
      #4      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
      #5      _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:774:19)
      #6      _StreamController._add (dart:async/stream_controller.dart:648:7)
      #7      _StreamController.add (dart:async/stream_controller.dart:596:5)
      #8      _RawSecureSocket._sendReadEvent (dart:io/secure_socket.dart:1107:19)
      #9      Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
      #10     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398:19)
      #11     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429:5)
      #12     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
    
This occurs because cancelling the subscription causes the socket to be immediately closed, while there may still be read events queued up; the _RawSecureSocket.read code has an explicit raise when the socket is closed (rather than just returning null as it is allowed to), and therefore an un-catchable exception occurs in the internal event loop code.
    
We only close the subscription in order to clean up after ourselves, so we can defer this until the websocket says it is done, which will in turn be triggered by closing the websocket gracefully (or by it being closed by the server end).
